### PR TITLE
Rename cleanup: monolog transition

### DIFF
--- a/.github/workflows/manually-build-zip.yml
+++ b/.github/workflows/manually-build-zip.yml
@@ -27,7 +27,7 @@ jobs:
         uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 #0.7.6
         with:
           type: 'zip'
-          filename: 'azure-insights-handler-for-wonolog.zip'
+          filename: 'azure-insights-handler-for-monolog.zip'
           exclusions: '*.git* .editorconfig composer* *.md package.json package-lock.json'
 
       - name: Release
@@ -35,5 +35,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: azure-insights-handler-for-wonolog.zip
+          files: azure-insights-handler-for-monolog.zip
           tag_name: ${{ github.event.inputs.tag }}

--- a/.github/workflows/on-release-add.zip.yml
+++ b/.github/workflows/on-release-add.zip.yml
@@ -22,7 +22,7 @@ jobs:
         uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 #0.7.6
         with:
           type: 'zip'
-          filename: 'azure-insights-handler-for-wonolog.zip'
+          filename: 'azure-insights-handler-for-monolog.zip'
           exclusions: '*.git* .editorconfig composer* *.md package.json package-lock.json'
 
       - name: Release
@@ -30,5 +30,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: azure-insights-handler-for-wonolog.zip
+          files: azure-insights-handler-for-monolog.zip
           tag_name: ${{ github.event.release.tag_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.1.0/) a
 
 ## [0.1.0] - 2025-08-30
 ### Added
-- Initial import of Azure Insights handler for Wonolog.
+- Initial import of Azure Insights handler (originally named for Wonolog).
 - WordPress `readme.txt` and `.gitignore`.
 - Modernized & restructured settings page UI with improved help tabs.
 - Comprehensive contextual help system (Overview, Connection & Security, Sampling & Batching, Performance Metrics, Redaction & Privacy, Retry & Async, CLI & Testing, Filters & Extensibility).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Azure Insights Handler for Wonolog
+# Azure Insights Handler for Monolog
 
-WordPress plugin forwarding Wonolog / Monolog logs and custom telemetry (traces, requests, exceptions, events, metrics) to Azure Application Insights.
+WordPress plugin forwarding Monolog logs and custom telemetry (traces, requests, exceptions, events, metrics) to Azure Application Insights.
 
 ## Features
 - Trace (MessageData) telemetry for Monolog records
@@ -36,11 +36,11 @@ WordPress plugin forwarding Wonolog / Monolog logs and custom telemetry (traces,
 ## Requirements
 - WordPress 6.5+
 - PHP 8.2+
-- Wonolog plugin (for Monolog integration) recommended
+- Monolog library via Composer (no separate Wonolog plugin required)
 
 ## Installation
 
-   1. Download [`azure-insights-handler-for-wonolog.zip`](https://github.com/soderlind/azure-insights-handler-for-wonolog/releases/latest/download/azure-insights-handler-for-wonolog.zip)
+    1. Download [`azure-insights-handler-for-monolog.zip`](https://github.com/soderlind/azure-insights-handler-for-monolog/releases/latest/download/azure-insights-handler-for-monolog.zip)
    2. Upload via  Plugins > Add New > Upload Plugin
    3. Activate in WP Admin.
    4. Provide Connection String (preferred) or legacy Instrumentation Key under Settings → Azure Insights.

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1,7 +1,7 @@
-# User Guide – Azure Insights Handler for Wonolog
+# User Guide – Azure Insights Handler for Monolog
 
 ## 1. What Is This Plugin?
-Azure Insights Handler for Wonolog is a WordPress plugin that bridges your site’s (or network’s) PHP / WordPress logs and custom operational telemetry into Azure Application Insights. It layers on top of Wonolog (which provides a Monolog logger inside WordPress) and converts Monolog records plus internally captured signals (requests, exceptions, performance metrics, custom events & metrics) into the JSON line payload Azure expects.
+Azure Insights Handler for Monolog is a WordPress plugin that bridges your site’s (or network’s) PHP / WordPress logs and custom operational telemetry into Azure Application Insights. It uses Monolog directly (Wonolog no longer required) and converts Monolog records plus internally captured signals (requests, exceptions, performance metrics, custom events & metrics) into the JSON line payload Azure expects.
 
 It’s intentionally lightweight (no heavy Azure SDK) and production‑oriented: sampling, batching, retry with exponential backoff, secure secret storage, adaptive throttling, correlation propagation, and rich redaction to keep sensitive data out of the wire.
 
@@ -30,7 +30,7 @@ It’s intentionally lightweight (no heavy Azure SDK) and production‑oriented:
 
 ## 4. Installation & Activation
 1. Copy plugin folder into `wp-content/plugins/`.
-2. (Optional) Run `composer install` inside the plugin directory if you rely on bundled vendor libs (Wonolog may already provide Monolog).
+2. (Optional) Run `composer install` inside the plugin directory if you rely on bundled vendor libs.
 3. Activate in the WordPress Admin (or network‑activate in multisite if you want global control).
 4. Provide a Connection String (Settings → Azure Insights) OR set it securely before WP loads:
 ```php
@@ -70,7 +70,7 @@ This allows ops to enforce mandatory settings via code / infrastructure, while s
 
 ## 8. Sending Telemetry
 ### Automatic
-- Logs via Wonolog / Monolog handlers.
+- Logs via Monolog handler.
 - Request telemetry on `shutdown` (duration, result code, correlation IDs).
 - Performance metrics gathered by hook instrumentation & thresholds.
 - Slow query metrics (if thresholds enabled).
@@ -180,7 +180,7 @@ Call `aiw_privacy_notice()` (or filter `aiw_privacy_notice_text`) to surface end
 Unless `AIW_PRESERVE_SETTINGS` is defined truthy, all plugin options & network options (prefixed `aiw_`) are removed during uninstall.
 
 ## 22. License & Attribution
-MIT. Built to complement Wonolog + Azure Application Insights for production WordPress observability.
+MIT. Built to complement Monolog + Azure Application Insights for production WordPress observability.
 
 ---
 Questions or improvement ideas? Open an issue or submit a PR. Happy observing!

--- a/azure-insights-handler-for-monolog.php
+++ b/azure-insights-handler-for-monolog.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Plugin Name: Azure Insights Handler for Monolog
+ * Description: Forwards Monolog logs and custom telemetry (requests, events, metrics, exceptions) to Azure Application Insights.
+ * Version: 0.4.0
+ * Author: Per Søderlind
+ * License: GPL2
+ * Text Domain: azure-insights-monolog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Constants
+define( 'AIW_PLUGIN_FILE', __FILE__ );
+define( 'AIW_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'AIW_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'AIW_PLUGIN_VERSION', '0.4.0' );
+
+// Optional disable & diagnostics (same semantics as previous version)
+if ( defined( 'AIW_DISABLE' ) && AIW_DISABLE ) {
+	if ( function_exists( 'error_log' ) )
+		@error_log( '[AIW] Disabled via AIW_DISABLE' );
+	return;
+}
+if ( ! function_exists( 'aiw_diag' ) ) {
+	function aiw_diag( string $m, array $c = [] ): void {
+		if ( defined( 'AIW_DIAGNOSTICS' ) && AIW_DIAGNOSTICS && function_exists( 'error_log' ) ) {
+			$line = '[AIW] ' . $m . ( $c ? ' ' . json_encode( $c ) : '' );
+			@error_log( $line );
+		}
+	}
+}
+
+if ( version_compare( PHP_VERSION, '8.2', '<' ) ) {
+	if ( function_exists( 'add_action' ) ) {
+		add_action( 'admin_notices', function () {
+			if ( current_user_can( 'activate_plugins' ) ) {
+				echo '<div class="notice notice-error"><p><strong>Azure Insights Handler for Monolog:</strong> Requires PHP 8.2+. Detected ' . esc_html( PHP_VERSION ) . '. Plugin not initialized.</p></div>';
+			}
+		} );
+	}
+	aiw_diag( 'php too low -> abort' );
+	return;
+}
+
+// Composer autoloader
+$autoload = AIW_PLUGIN_DIR . 'vendor/autoload.php';
+if ( file_exists( $autoload ) ) {
+	require_once $autoload;
+	aiw_diag( 'composer autoload loaded' );
+} else {
+	aiw_diag( 'composer autoload missing', [ 'path' => $autoload ] );
+}
+
+// PSR-4 fallback for our namespace
+spl_autoload_register( function ($class) {
+	if ( strpos( $class, 'AzureInsightsMonolog\\' ) !== 0 )
+		return;
+	$rel  = substr( $class, strlen( 'AzureInsightsMonolog\\' ) );
+	$rel  = str_replace( '\\', '/', $rel );
+	$file = AIW_PLUGIN_DIR . 'src/' . $rel . '.php';
+	if ( file_exists( $file ) )
+		require_once $file;
+} );
+
+// Updater
+try {
+	$updater = AzureInsightsMonolog\Updater\GitHubPluginUpdater::create_with_assets(
+		'https://github.com/soderlind/azure-insights-handler-for-monolog',
+		AIW_PLUGIN_FILE,
+		'azure-insights-handler-for-monolog',
+		'/azure-insights-handler-for-monolog\\.zip/',
+		'main'
+	);
+	aiw_diag( 'updater initialized' );
+} catch (\Throwable $e) {
+	aiw_diag( 'updater failed', [ 'error' => $e->getMessage() ] );
+}
+
+// Activation / Deactivation
+register_activation_hook( __FILE__, function () {
+	if ( class_exists( 'AzureInsightsMonolog\\Plugin' ) ) {
+		AzureInsightsMonolog\Plugin::activate();
+	}
+} );
+register_deactivation_hook( __FILE__, function () {
+	if ( class_exists( 'AzureInsightsMonolog\\Plugin' ) ) {
+		AzureInsightsMonolog\Plugin::deactivate();
+	}
+} );
+
+// Bootstrap
+add_action( 'plugins_loaded', function () {
+	aiw_diag( 'plugins_loaded' );
+	if ( ! class_exists( '\\Monolog\\Logger' ) ) {
+		add_action( 'admin_notices', function () {
+			if ( current_user_can( 'activate_plugins' ) ) {
+				echo '<div class="notice notice-error"><p><strong>Azure Insights Handler for Monolog:</strong> Monolog library not found. Run <code>composer install</code> inside the plugin directory.</p></div>';
+			}
+		} );
+		aiw_diag( 'monolog missing' );
+		return;
+	}
+	if ( class_exists( 'AzureInsightsMonolog\\Plugin' ) ) {
+		try {
+			aiw_diag( 'boot start' );
+			AzureInsightsMonolog\Plugin::instance()->boot();
+			aiw_diag( 'boot done' );
+		} catch (\Throwable $e) {
+			aiw_diag( 'boot failed', [ 'error' => $e->getMessage() ] );
+		}
+	}
+} );
+
+// Helpers
+require_once AIW_PLUGIN_DIR . 'src/Helpers/functions.php';
+
+// WP-CLI
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	$cli = AIW_PLUGIN_DIR . 'src/CLI/Commands.php';
+	if ( file_exists( $cli ) )
+		require_once $cli;
+}

--- a/azure-insights-handler-for-wonolog.php
+++ b/azure-insights-handler-for-wonolog.php
@@ -1,11 +1,13 @@
 <?php
+// Deprecated bootstrap file retained temporarily for backwards compatibility.
+// Please migrate to azure-insights-handler-for-monolog.php and remove this file in a future release.
 /**
- * Plugin Name: Azure Insights Handler for Wonolog
- * Description: Integrates Wonolog (Monolog) with Azure Application Insights for enhanced logging and telemetry.
+ * Plugin Name: Azure Insights Handler (Deprecated Loader)
+ * Description: Deprecated loader kept for backward compatibility. Use Azure Insights Handler for Monolog.
  * Version: 0.3.0
  * Author: Per Søderlind
  * License: GPL2
- * Text Domain: azure-insights-wonolog
+ * Text Domain: azure-insights-monolog
  */
 
 // Abort if accessed directly.
@@ -26,11 +28,13 @@ if ( file_exists( $aiw_composer ) ) {
 	require_once $aiw_composer;
 }
 
+
+// Back-compat: provide class aliases for old namespace if code elsewhere still references it.
 spl_autoload_register( function ($class) {
-	if ( strpos( $class, 'AzureInsightsWonolog\\' ) !== 0 ) {
+	if ( strpos( $class, 'AzureInsightsMonolog\\' ) !== 0 ) {
 		return;
 	}
-	$relative = substr( $class, strlen( 'AzureInsightsWonolog\\' ) );
+	$relative = substr( $class, strlen( 'AzureInsightsMonolog\\' ) );
 	$relative = str_replace( '\\', '/', $relative );
 	$path     = AIW_PLUGIN_DIR . 'src/' . $relative . '.php';
 	if ( file_exists( $path ) ) {
@@ -38,26 +42,47 @@ spl_autoload_register( function ($class) {
 	}
 } );
 
+// Legacy namespace loader (temporary shim) – map AzureInsightsWonolog\Foo to AzureInsightsMonolog\Foo classes if possible.
+spl_autoload_register( function ($class) {
+	if ( strpos( $class, 'AzureInsightsWonolog\\' ) !== 0 ) {
+		return;
+	}
+	$new = 'AzureInsightsMonolog\\' . substr( $class, strlen( 'AzureInsightsWonolog\\' ) );
+	if ( class_exists( $new ) || interface_exists( $new ) || trait_exists( $new ) ) {
+		class_alias( $new, $class );
+		return;
+	}
+	$relative = substr( $new, strlen( 'AzureInsightsMonolog\\' ) );
+	$relative = str_replace( '\\', '/', $relative );
+	$path     = AIW_PLUGIN_DIR . 'src/' . $relative . '.php';
+	if ( file_exists( $path ) ) {
+		require_once $path;
+		if ( class_exists( $new ) ) {
+			class_alias( $new, $class );
+		}
+	}
+} );
 
-$additional_javascript_updater = AzureInsightsWonolog\Updater\GitHubPluginUpdater::create_with_assets(
-	'https://github.com/soderlind/azure-insights-handler-for-wonolog',
+
+$additional_javascript_updater = AzureInsightsMonolog\Updater\GitHubPluginUpdater::create_with_assets(
+	'https://github.com/soderlind/azure-insights-handler-for-monolog',
 	AIW_PLUGIN_FILE,
-	'azure-insights-handler-for-wonolog',
-	'/azure-insights-handler-for-wonolog\.zip/',
+	'azure-insights-handler-for-monolog',
+	'/azure-insights-handler-for-monolog\.zip/',
 	'main'
 );
 
 
 // Activation / Deactivation hooks.
 register_activation_hook( __FILE__, function () {
-	if ( class_exists( 'AzureInsightsWonolog\\Plugin' ) ) {
-		AzureInsightsWonolog\Plugin::activate();
+	if ( class_exists( 'AzureInsightsMonolog\\Plugin' ) ) {
+		AzureInsightsMonolog\Plugin::activate();
 	}
 } );
 
 register_deactivation_hook( __FILE__, function () {
-	if ( class_exists( 'AzureInsightsWonolog\\Plugin' ) ) {
-		AzureInsightsWonolog\Plugin::deactivate();
+	if ( class_exists( 'AzureInsightsMonolog\\Plugin' ) ) {
+		AzureInsightsMonolog\Plugin::deactivate();
 	}
 } );
 
@@ -67,13 +92,13 @@ add_action( 'plugins_loaded', function () {
 		// Defer admin notice until admin_notices hook.
 		add_action( 'admin_notices', function () {
 			if ( current_user_can( 'activate_plugins' ) ) {
-				echo '<div class="notice notice-error"><p><strong>Azure Insights Handler for Wonolog:</strong> Monolog library not found. Run <code>composer install</code> inside the plugin directory or install Wonolog.</p></div>';
+				echo '<div class="notice notice-error"><p><strong>Azure Insights Handler for Monolog:</strong> Monolog library not found. Run <code>composer install</code> inside the plugin directory.</p></div>';
 			}
 		} );
 		return;
 	}
-	if ( class_exists( 'AzureInsightsWonolog\Plugin' ) ) {
-		AzureInsightsWonolog\Plugin::instance()->boot();
+	if ( class_exists( 'AzureInsightsMonolog\\Plugin' ) ) {
+		AzureInsightsMonolog\Plugin::instance()->boot();
 	}
 } );
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Azure Insights Handler for Wonolog ===
+=== Azure Insights Handler for Monolog ===
 Contributors: persoderlind
 Tags: azure, application insights, logging, telemetry, monitoring
 Requires at least: 6.5
@@ -8,10 +8,10 @@ Stable tag: 0.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Integrates Wonolog (Monolog) with Azure Application Insights providing structured telemetry, sampling, redaction, retry queue, async batching, and an admin status dashboard.
+Forwards Monolog logs and custom telemetry (traces, requests, exceptions, events, metrics) to Azure Application Insights with sampling, redaction, retry queue, async batching, and an admin status dashboard.
 
 == Description ==
-This plugin bridges your WordPress (and Wonolog / Monolog) logging + custom operational metrics to **Azure Application Insights**.
+This plugin bridges your WordPress (Monolog) logging + custom operational metrics to **Azure Application Insights**.
 
 It batches & sends traces, requests, exceptions, events, and custom metrics with optional adaptive sampling, advanced redaction, a resilient retry queue (including transient storage mode), async cron dispatch, correlation headers, and a native WordPress status dashboard.
 
@@ -33,7 +33,7 @@ Key features:
 Filters let you alter sampling, redaction, correlation, and mutate batches pre-send.
 
 == Installation ==
-1. Upload or clone into `wp-content/plugins/azure-insights-handler-for-wonolog`.
+1. Upload or clone into `wp-content/plugins/azure-insights-handler-for-monolog`.
 2. Activate the plugin.
 3. In Azure create / locate an Application Insights resource and copy its Connection String.
 4. Open: Azure Insights (top-level admin menu) → Settings. Paste Connection String (preferred) or Instrumentation Key.
@@ -47,7 +47,7 @@ define( 'AIW_CONNECTION_STRING', 'InstrumentationKey=...;IngestionEndpoint=...' 
 == Frequently Asked Questions ==
 
 = Do I need the Wonolog plugin? =
-Recommended for seamless Monolog integration, but Monolog availability (via another source) is sufficient.
+No. Direct Monolog loading via Composer is sufficient; Wonolog is no longer required. A deprecated loader file is included only for backward compatibility with old paths.
 
 = How do I change the sampling rate dynamically? =
 Adjust in settings UI or override per-record with filter `aiw_should_sample`.


### PR DESCRIPTION
Renamed references from Wonolog to Monolog in docs/design/workflows, added main plugin bootstrap file, retained deprecated loader for backward compatibility. Also cleaned unintended modifications by resetting unrelated source files.